### PR TITLE
Extch 390 slide persistence

### DIFF
--- a/src/templates/Flipbook/index.js
+++ b/src/templates/Flipbook/index.js
@@ -104,7 +104,6 @@ function Flipbook({ data, pageContext, location }) {
 
   // get default locale info
   const defaultLocale = localesInfo.filter((locale) => locale.default === true);
-  console.log('default?', `${window.origin}/${defaultLocale[0].code}/${pageContext.slug}?currentSlide=0`);
 
   // Filter out current locale
   const buttonLocales = localesInfo.filter((locale) => !pageContext.locales.includes(locale.code));

--- a/src/templates/Flipbook/index.js
+++ b/src/templates/Flipbook/index.js
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { graphql, Link } from 'gatsby';
 import PropTypes from 'prop-types';
 import { GatsbyImage, getImage } from 'gatsby-plugin-image';
@@ -100,11 +100,24 @@ function Flipbook({ data, pageContext, location }) {
 
   // Array of multi-locale slides
   const slides = localeNodes[0].slides.map((slide, i) => localeNodes.map((node) => node.slides[i]));
-
   const localesInfo = data.allContentfulLocale.edges.map((edge) => edge.node);
+
+  // get default locale info
+  const defaultLocale = localesInfo.filter((locale) => locale.default === true);
+  console.log('default?', `${window.origin}/${defaultLocale[0].code}/${pageContext.slug}?currentSlide=0`);
+
   // Filter out current locale
   const buttonLocales = localesInfo.filter((locale) => !pageContext.locales.includes(locale.code));
   const intlNames = new Intl.DisplayNames('en', { type: 'language', languageDisplay: 'dialect' });
+
+  // To sync slide index between locales
+  const [currentSlide, setCurrentSlide] = useState(null);
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    let slideIndex = params.get('currentSlide');
+    if (!slideIndex) slideIndex = 0;
+    setCurrentSlide(parseInt(slideIndex, 10));
+  }, []);
 
   // Inactivity timeout
   const { inactivityTimeout } = localeNodes[0];
@@ -112,7 +125,7 @@ function Flipbook({ data, pageContext, location }) {
     timeout: inactivityTimeout * 1000,
     debounce: 500,
     startOnMount: false,
-    onIdle: () => window.location.reload(false),
+    onIdle: () => window.location.replace(`${window.origin}/${defaultLocale[0].code}/${pageContext.slug}?currentSlide=0`),
   });
 
   const getAltText = (altObj) => {
@@ -120,12 +133,27 @@ function Flipbook({ data, pageContext, location }) {
     return 'Image';
   };
 
+  const setUrlParam = (key, value) => {
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search);
+      urlParams.set(key, value);
+      const newUrl = `${window.location.pathname}?${urlParams.toString()}`;
+      window.history.replaceState(null, null, newUrl);
+    }
+  };
+
+  const onSlideChange = (swiper) => {
+    const { realIndex } = swiper;
+    setUrlParam('currentSlide', realIndex);
+    setCurrentSlide(realIndex);
+  };
+
   const renderLocaleButtons = () => (
     <div className="locale-buttons">
       { buttonLocales && buttonLocales.map((localeInfo) => (
         <Link
           key={localeInfo.code}
-          to={`/${localeInfo.code}/${pageContext.slug}`}
+          to={`/${localeInfo.code}/${pageContext.slug}?currentSlide=${currentSlide}`}
           className={`locale-button ${localeInfo.code}`}
         >
           {intlNames.of(localeInfo.code)}
@@ -186,7 +214,10 @@ function Flipbook({ data, pageContext, location }) {
 
   return (
     <>
+      {currentSlide !== null
+      && (
       <Swiper
+        initialSlide={currentSlide}
         spaceBetween={0}
         slidesPerView={1}
         centeredSlides
@@ -195,10 +226,12 @@ function Flipbook({ data, pageContext, location }) {
         pagination={{
           clickable: true,
         }}
+        onSlideChange={onSlideChange}
         className={localeNodes[0].slug}
       >
         {renderSlides}
       </Swiper>
+      )}
       {renderLocaleButtons()}
     </>
   );


### PR DESCRIPTION
Adds feature to persist slides between locales (as implemented in ctsc-eating-in-space redux.
https://smm.atlassian.net/browse/EXTCH-390

Pull this branch and connect to a flipbook with multiple locale content.
When locale is changed, instead of reloading to a title slide, the slide number displayed should stay the same.
On timeout, the title slide in the default language should display.

### Preparation checklist

* [X] Merge `main` into your branch and resolve resulting conflicts
* [X] Select one or multiple reviewers who are well suited to discuss your changes

### Writing a helpful description

* [X] Link to the specific user-story being addressed, and describe how you've addressed it
* [X] Describe how your changes should be tested
